### PR TITLE
每处理一条数据前,把过期时间设置为空,避免如果一个 key 没有设置过期时间,返回了最近一条会过期的 key 的过期时间

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -103,6 +103,9 @@ func (p *Parser) Next() (interface{}, error) {
 		p.initialized = true
 	}
 
+	//没处理一条数据前,把过期时间设置为空
+	p.expiry = nil
+
 	for {
 		data, err := p.nextLoop()
 

--- a/parser.go
+++ b/parser.go
@@ -103,7 +103,6 @@ func (p *Parser) Next() (interface{}, error) {
 		p.initialized = true
 	}
 
-	//没处理一条数据前,把过期时间设置为空
 	p.expiry = nil
 
 	for {


### PR DESCRIPTION
当一个记录,不存在 FC 和 FD 两个过期时间的 flag 时, parser 中并不会对其做任何特殊处理,就会导致如果当前 key 设置不过期,就会返回之前处理的最近一条设置了过期时间的 key 的过期时间.