### PR TITLE
reset the expiry to nil when we process the next key

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -103,6 +103,8 @@ func (p *Parser) Next() (interface{}, error) {
 		p.initialized = true
 	}
 
+	p.expiry = nil
+
 	for {
 		data, err := p.nextLoop()
 


### PR DESCRIPTION
if a key has no expiry and the previous key has expiry, the old key's expiry will assign to the new key. So we should reset the expiry at the begin of process the next key.